### PR TITLE
Fix/request response struct

### DIFF
--- a/cmd/game_api/server.go
+++ b/cmd/game_api/server.go
@@ -15,9 +15,6 @@ func main() {
 	// コントローラーの初期化
 	userController := controllers.NewUserController(sqlHandler, jwtHandler)
 
-	// "/hello"に対しての処理を設定
-	http.HandleFunc("/hello", controllers.HelloHandler)
-	http.HandleFunc("/good-night", userController.GoodnightHandler)
 	http.HandleFunc("/users/get", userController.Index)
 
 	http.HandleFunc("/user/create", userController.Create)

--- a/internal/game_api/user/controllers/user_controller.go
+++ b/internal/game_api/user/controllers/user_controller.go
@@ -7,7 +7,6 @@ import (
 	"ca-tech-dojo/pkg/jwt"
 	"ca-tech-dojo/internal/game_api/user/models"
 	"encoding/json"
-	"log"
 	"io/ioutil"
 )
 
@@ -25,17 +24,6 @@ func NewUserController(sqlHandler *database.SqlHandler, jwtHandler *jwt.JwtHandl
 	}
 }
 
-// "/hello"に対しての処理
-func HelloHandler(w http.ResponseWriter, r *http.Request) {
-	// w に書き込み
-	fmt.Fprint(w, "hello world!\n")
-}
-
-func (controller UserController) GoodnightHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "good night!\n")
-}
-
-
 // ユーザー一覧をJSONで返す
 func (controller *UserController) Index(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet { // GETリクエストのみ許可
@@ -49,7 +37,6 @@ func (controller *UserController) Index(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		fmt.Fprint(w, err)
 	}
-	log.Print("The users struct is ", users)
 
 	usersByte, err := json.Marshal(users) // 構造体を []byte へ変換
     if err != nil {
@@ -60,7 +47,7 @@ func (controller *UserController) Index(w http.ResponseWriter, r *http.Request) 
 	fmt.Fprint(w, usersJson)
 }
 
-// トークンを生成してユーザーを保存して、保存したユーザーidを返す
+// トークンを生成してユーザーを保存して、保存したユーザーのトークンをJSONで返す
 func (controller *UserController) Create(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost { // POSTリクエストのみ許可
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/game_api/user/models/user.go
+++ b/internal/game_api/user/models/user.go
@@ -1,8 +1,16 @@
 package models
 
+type UserCreateRequest struct {
+	Name  string `json:"name"`
+}
+
+type UserCreateResponse struct {
+	Token string `json:"token"`
+}
+
 type User struct {
-	Name  string
-	Token string
+	Name string `json:"name"`
+	Token string `json:"token"`
 }
 
 type Users []User

--- a/pkg/database/user_repository.go
+++ b/pkg/database/user_repository.go
@@ -36,8 +36,8 @@ func (repo *UserRepository) GetAll() (users models.Users, err error){
 }
 
 // DBにユーザーを保存して、保存したユーザーidを返す
-func (repo *UserRepository) Create(u models.User) (id int64, err error) {
-	result, err := repo.SqlHandler.Conn.Exec("INSERT INTO users (name, token) VALUES (?, ?)", u.Name, u.Token)
+func (repo *UserRepository) Create(name string, tokenString string) (id int64, err error) {
+	result, err := repo.SqlHandler.Conn.Exec("INSERT INTO users (name, token) VALUES (?, ?)", name, tokenString)
 	if err != nil {
 		return
 	}

--- a/pkg/database/user_repository.go
+++ b/pkg/database/user_repository.go
@@ -50,26 +50,18 @@ func (repo *UserRepository) Create(name string, tokenString string) (id int64, e
 	return
 }
 
-// データベースのユーザーをidで検索して返す
-func (repo *UserRepository) FindById(id int64) (user models.User, err error) {
-	row, err := repo.SqlHandler.Conn.Query("SELECT name, token FROM users where id = ?", id)
+// DBに保存されているユーザーのトークンをidで検索して返す
+func (repo *UserRepository) FindTokenById(id int64) (tokenString string, err error) {
+	row, err := repo.SqlHandler.Conn.Query("SELECT token FROM users where id = ?", id)
 	if err != nil {
 		return
 	}
 	defer row.Close()
 
-	var name string
-	var token string
-
 	row.Next()
-	if err = row.Scan(&name, &token); err != nil {
+	if err = row.Scan(&tokenString); err != nil {
 		return
 	}
-
-	user = models.User {
-		Name: name,
-		Token: token,
-	}
-
+	
 	return
 }

--- a/pkg/jwt/jwt_handler.go
+++ b/pkg/jwt/jwt_handler.go
@@ -3,7 +3,6 @@ package jwt
 import (
 	"log"
 	jwt "github.com/dgrijalva/jwt-go"
-	"ca-tech-dojo/internal/game_api/user/models"
 	"time"
 	"github.com/google/uuid"
 )
@@ -22,7 +21,7 @@ const (
 )
 
 // トークンを生成して、ユーザーの構造体に格納して返す
-func (handler *JwtHandler) Create(u models.User) (user models.User, err error) {
+func (handler *JwtHandler) Create(name string) (tokenString string, err error) {
 
 	// 署名アルゴリズムを指定してトークン型を生成
 	token := jwt.New(jwt.SigningMethodHS256)
@@ -34,20 +33,17 @@ func (handler *JwtHandler) Create(u models.User) (user models.User, err error) {
     }
 
 	claims := token.Claims.(jwt.MapClaims) // クレームを設定
-	claims["name"] = u.Name
+	claims["name"] = name
 	claims["iat"] = time.Now().Unix() // トークンの発行時間
 	claims["sub"] = uu.String() // 一意な識別子
 
 	log.Print("the uuid is ", uu.String())
 
-	tokenString, err := token.SignedString([]byte(signKey)) // 署名
+	tokenString, err = token.SignedString([]byte(signKey)) // 署名
 	if err != nil {
 		log.Print("error is ", err.Error())
 		return
 	}
-
-	u.Token = tokenString
-	user = u
-
+	
 	return
 }

--- a/pkg/jwt/jwt_handler.go
+++ b/pkg/jwt/jwt_handler.go
@@ -20,7 +20,7 @@ const (
 	signKey = "ca-tech-dojo-key" // 共通鍵
 )
 
-// トークンを生成して、ユーザーの構造体に格納して返す
+// トークンを生成して返す
 func (handler *JwtHandler) Create(name string) (tokenString string, err error) {
 
 	// 署名アルゴリズムを指定してトークン型を生成
@@ -36,8 +36,6 @@ func (handler *JwtHandler) Create(name string) (tokenString string, err error) {
 	claims["name"] = name
 	claims["iat"] = time.Now().Unix() // トークンの発行時間
 	claims["sub"] = uu.String() // 一意な識別子
-
-	log.Print("the uuid is ", uu.String())
 
 	tokenString, err = token.SignedString([]byte(signKey)) // 署名
 	if err != nil {


### PR DESCRIPTION
リクエストとレスポンスで構造体を分けて記述
以下、主な変更点

- リクエストとレスポンスそれぞれの構造体を定義
- 構造体にフィールドタグを追加
- 引数や返り値に構造体を多用しないよう変更
トークン作成は、nameを引数にしてトークン文字列を返す
ユーザーの保存は、nameとトークン文字列を引数にする
ユーザーidでのユーザー情報の検索は、User構造体ではなくトークン文字列を返す